### PR TITLE
Add python-multipart dependency

### DIFF
--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -2,6 +2,7 @@
 # output rather than fail loudly. Versions match the current working image.
 fastapi==0.116.2
 uvicorn==0.35.0
+python-multipart==0.0.20
 insightface==0.7.3
 onnxruntime==1.22.1
 numpy==1.24.3


### PR DESCRIPTION
## Summary
- Add `python-multipart==0.0.20` to `inference/requirements.txt`, required by FastAPI for parsing multipart form/file uploads

## Test plan
- [ ] Verify inference service installs deps and file-upload endpoints work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)